### PR TITLE
bug(DetectNewline): Use detectNewline#graceful

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -235,7 +235,7 @@ function createSourceMapFile(opts) {
 // TODO: any way to make this function not require file?
 function commentFormatter(file, url) {
   // TODO: can this be built into convert-source-map?
-  var newline = detectNewline(file.contents.toString());
+  var newline = detectNewline.graceful(file.contents.toString());
 
   // TODO: Not sure I agree with this
   if (file.extname !== '.js' && file.extname !== '.css') {


### PR DESCRIPTION
- detectNewline by default returns `null` if no newline is detected, they
  provide another method called `graceful` that defaults to `\n` instead
  of `null`

Attempt at a simple fix for #3 