### PR TITLE
feat!: Support streaming contents

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,14 +5,17 @@ var os = require('os');
 var TextDecoder = require('util').TextDecoder;
 
 var fs = require('graceful-fs');
+var Readable = require('streamx').Readable;
+var Transform = require('streamx').Transform;
 var nal = require('now-and-later');
 var File = require('vinyl');
 var convert = require('convert-source-map');
 
 var urlRegex = /^(https?|webpack(-[^:]+)?):\/\//;
 
-var bufCR = Buffer.from('\r\n');
-var bufNL = Buffer.from('\n');
+var bufCR = Buffer.from('\r');
+var bufCRLF = Buffer.from('\r\n');
+var bufLF = Buffer.from('\n');
 var bufEOL = Buffer.from(os.EOL);
 
 var decoder = new TextDecoder('utf-8', { ignoreBOM: false });
@@ -39,7 +42,11 @@ function loadSourceMap(file, state, callback) {
     state.path = file.dirname;
     state.content = convert.removeComments(state.content);
     // Remove source map comment from source
-    file.contents = Buffer.from(state.content, 'utf8');
+    if (file.isStream()) {
+      file.contents = Readable.from(state.content);
+    } else {
+      file.contents = Buffer.from(state.content, 'utf8');
+    }
     return callback();
   }
 
@@ -51,7 +58,11 @@ function loadSourceMap(file, state, callback) {
     mapFile = path.resolve(file.dirname, mapComment[1] || mapComment[2]);
     state.content = convert.removeMapFileComments(state.content);
     // Remove source map comment from source
-    file.contents = Buffer.from(state.content, 'utf8');
+    if (file.isStream()) {
+      file.contents = Readable.from(state.content);
+    } else {
+      file.contents = Buffer.from(state.content, 'utf8');
+    }
   } else {
     // If no comment try map file with same name as source file
     mapFile = file.path + '.map';
@@ -232,21 +243,98 @@ function writeSourceMaps(file, destPath, callback) {
   }
 
   // Append source map comment
-  file.contents = appendBuffer(file.contents, Buffer.from(comment));
+  file = append(file, Buffer.from(comment));
 
   callback(null, file, sourceMapFile);
 }
 
+function append(file, comment) {
+  if (file.isBuffer()) {
+    file.contents = appendBuffer(file.contents, comment);
+  }
+
+  if (file.isStream()) {
+    file.contents = file.contents.pipe(appendStream(comment));
+  }
+
+  return file;
+}
+
 function appendBuffer(buf1, buf2) {
   var eol;
-  if (buf1.slice(-2).equals(bufCR)) {
+  if (buf1.slice(-2).equals(bufCRLF)) {
+    eol = bufCRLF;
+  } else if (buf1.slice(-1).equals(bufLF)) {
+    eol = bufLF;
+  } else if (buf1.slice(-1).equals(bufCR)) {
     eol = bufCR;
-  } else if (buf1.slice(-1).equals(bufNL)) {
-    eol = bufNL;
   } else {
     eol = bufEOL;
   }
   return Buffer.concat([buf1, buf2, eol]);
+}
+
+// Implementation heavily inspired by https://github.com/maxogden/eol-stream
+function appendStream(comment) {
+  var crAtEnd = false;
+  var eol = bufEOL;
+
+  return new Transform({
+    transform: detect,
+    flush: flush,
+  });
+
+  function detect(chunk, callback) {
+    var isString = typeof chunk === 'string';
+
+    var cr = isString ? bufCR.toString() : bufCR[0];
+    var lf = isString ? bufLF.toString() : bufLF[0];
+
+    if (crAtEnd) {
+      if (chunk[0] === lf) {
+        eol = bufCRLF;
+      } else {
+        eol = bufCR;
+      }
+      // Reset the flag because we search for the _last_ line ending
+      crAtEnd = false;
+      return callback(null, chunk);
+    }
+
+    var i = 0;
+    while (i < chunk.length) {
+      if (chunk[i] === cr) {
+        if (i === chunk.length - 1) {
+          // Need to read the next chunk to see if it is a CRLF
+          crAtEnd = true;
+          i += 1;
+        } else if (chunk[i + 1] === lf) {
+          eol = bufCRLF;
+          // We skip two because we saw the CRLF
+          i += 2;
+        } else {
+          eol = bufCR;
+          i += 1;
+        }
+        continue;
+      }
+
+      if (chunk[i] === lf) {
+        eol = bufLF;
+      }
+
+      i += 1;
+    }
+
+    callback(null, chunk);
+  }
+
+  function flush(cb) {
+    this.push(comment);
+    this.push(eol);
+
+    cb();
+  }
 }
 
 function normalizeRelpath(fp) {

--- a/package.json
+++ b/package.json
@@ -27,7 +27,9 @@
     "convert-source-map": "^1.8.0",
     "graceful-fs": "^4.2.10",
     "now-and-later": "^3.0.0",
-    "vinyl": "^3.0.0"
+    "streamx": "^2.12.5",
+    "vinyl": "^3.0.0",
+    "vinyl-contents": "^2.0.0"
   },
   "devDependencies": {
     "eslint": "^7.32.0",
@@ -36,7 +38,7 @@
     "expect": "^27.5.1",
     "mocha": "^8.4.0",
     "nyc": "^15.1.0",
-    "streamx": "^2.12.5"
+    "readable-stream": "^3.6.0"
   },
   "nyc": {
     "extension": [

--- a/test/add.js
+++ b/test/add.js
@@ -5,8 +5,6 @@ var File = require('vinyl');
 var path = require('path');
 var expect = require('expect');
 var convert = require('convert-source-map');
-var streamx = require('streamx');
-var stream = require('stream');
 
 var sourcemaps = require('..');
 
@@ -66,28 +64,6 @@ describe('add', function () {
       expect(
         err instanceof Error &&
           err.message === 'vinyl-sourcemap-add: Not a vinyl file'
-      ).toBeTruthy();
-      done();
-    });
-  });
-
-  it('errors if file argument is a Vinyl object with contents from streamx.Readable', function (done) {
-    var file = makeFile(streamx.Readable.from([]));
-    sourcemaps.add(file, function (err) {
-      expect(
-        err instanceof Error &&
-          err.message === 'vinyl-sourcemap-add: Streaming not supported'
-      ).toBeTruthy();
-      done();
-    });
-  });
-
-  it('errors if file argument is a Vinyl object with contents from stream.Readable', function (done) {
-    var file = makeFile(stream.Readable.from([]));
-    sourcemaps.add(file, function (err) {
-      expect(
-        err instanceof Error &&
-          err.message === 'vinyl-sourcemap-add: Streaming not supported'
       ).toBeTruthy();
       done();
     });
@@ -437,3 +413,448 @@ describe('add (buffer contents)', function () {
     });
   });
 });
+
+function suite(moduleName) {
+  var stream = require(moduleName);
+
+  describe('add (' + moduleName + ' contents)', function () {
+    function concat(fn, timeout) {
+      var items = [];
+      return new stream.Writable({
+        objectMode: true,
+        write: function (chunk, enc, cb) {
+          if (typeof enc === 'function') {
+            cb = enc;
+          }
+          setTimeout(function () {
+            items.push(chunk);
+            cb();
+          }, timeout || 1);
+        },
+        final: function (cb) {
+          if (typeof fn === 'function') {
+            fn(items.join(''));
+          }
+
+          cb();
+        },
+      });
+    }
+
+    function makeFileWithInlineSourceMap() {
+      var inline = convert.fromObject(makeSourcemap()).toComment();
+      return new File({
+        cwd: __dirname,
+        base: path.join(__dirname, 'assets'),
+        path: path.join(__dirname, 'assets', 'all.js'),
+        contents: stream.Readable.from(
+          'console.log("line 1.1"),console.log("line 1.2"),console.log("line 2.1"),console.log("line 2.2");\n' +
+            inline
+        ),
+      });
+    }
+
+    it('does not error if file argument is a Vinyl object with Stream contents', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.add(file, function (err) {
+        expect(err).toBeFalsy();
+        done();
+      });
+    });
+
+    it('surfaces an error from the stream', function (done) {
+      var file = makeFile(
+        new stream.Readable({
+          read: function (cb) {
+            var err = new Error('boom');
+            if (typeof cb === 'function') {
+              cb(err);
+            } else {
+              this.destroy(err);
+            }
+          },
+        })
+      );
+      sourcemaps.add(file, function (err) {
+        expect(err).toBeTruthy();
+        expect(err.message).toEqual('boom');
+        done();
+      });
+    });
+
+    it('keeps the contents as a stream after processing sourceMaps', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile).toBeTruthy();
+        expect(File.isVinyl(outFile)).toEqual(true);
+        expect(file.isStream()).toEqual(true);
+        done(err);
+      });
+    });
+
+    it('calls back with the untouched file if file already has a sourcemap', function (done) {
+      var sourceMap = {
+        version: 3,
+        names: [],
+        mappings: '',
+        sources: ['test.js'],
+        sourcesContent: ['testContent'],
+      };
+
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.sourceMap = sourceMap;
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile).toBeTruthy();
+        expect(File.isVinyl(outFile)).toEqual(true);
+        expect(outFile.sourceMap).toBe(sourceMap);
+        expect(outFile).toBe(file);
+        done(err);
+      });
+    });
+
+    it('adds an empty sourceMap if none are found', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources[0]).toEqual('helloworld.js');
+        expect(outFile.sourceMap.sourcesContent[0]).toEqual(sourceContent);
+        expect(outFile.sourceMap.names).toEqual([]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('imports an existing inline sourcemap', function (done) {
+      var file = makeFileWithInlineSourceMap();
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['test1.js', 'test2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'console.log("line 1.1");\nconsole.log("line 1.2");\n',
+          'console.log("line 2.1");\nconsole.log("line 2.2");',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual(
+          'AAAAA,QAAAC,IAAA,YACAD,QAAAC,IAAA,YCDAD,QAAAC,IAAA,YACAD,QAAAC,IAAA'
+        );
+        done(err);
+      });
+    });
+
+    it('removes an imported inline sourcemap', function (done) {
+      var file = makeFileWithInlineSourceMap();
+      sourcemaps.add(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).not.toMatch(/sourceMappingURL/);
+        }
+
+        stream.pipeline([outFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('loads external sourcemap file from //# comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld2.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['helloworld2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'source content from source map',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('removes an imported sourcemap file //# comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld2.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).not.toMatch(/sourceMappingURL/);
+        }
+
+        stream.pipeline([outFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('loads external sourcemap file from //@ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//@ sourceMappingURL=helloworld2.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['helloworld2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'source content from source map',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('removes an imported sourcemap file //@ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//@ sourceMappingURL=helloworld2.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).not.toMatch(/sourceMappingURL/);
+        }
+
+        stream.pipeline([outFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('loads external sourcemap file from /*# */ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '/*# sourceMappingURL=helloworld2.js.map */'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['helloworld2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'source content from source map',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('removes an imported sourcemap file /*# */ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '/*# sourceMappingURL=helloworld2.js.map */'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).not.toMatch(/sourceMappingURL/);
+        }
+
+        stream.pipeline([outFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('loads external sourcemap file from /*@ */ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '/*@ sourceMappingURL=helloworld2.js.map */'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['helloworld2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'source content from source map',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('removes an imported sourcemap file /*@ */ comment', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '/*@ sourceMappingURL=helloworld2.js.map */'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).not.toMatch(/sourceMappingURL/);
+        }
+
+        stream.pipeline([outFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('loads external sourcemap by filename if no source mapping comment', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.path = file.path.replace('helloworld.js', 'helloworld2.js');
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.version).toEqual(3);
+        expect(outFile.sourceMap.sources).toEqual(['helloworld2.js']);
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          'source content from source map',
+        ]);
+        expect(outFile.sourceMap.mappings).toEqual('');
+        done(err);
+      });
+    });
+
+    it('loads sourcesContent if missing', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld3.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          content,
+          "console.log('test1');\n",
+        ]);
+        done(err);
+      });
+    });
+
+    it('does not error when source file for sourcesContent not found', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld4.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sources).toEqual([
+          'helloworld.js',
+          'missingfile',
+        ]);
+        expect(outFile.sourceMap.sourcesContent).toEqual([content, null]);
+        done(err);
+      });
+    });
+
+    it('uses unix style paths in sourcemap', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.base = file.cwd;
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.file).toEqual('assets/helloworld.js');
+        expect(outFile.sourceMap.sources).toEqual(['assets/helloworld.js']);
+        done(err);
+      });
+    });
+
+    it('normalizes Windows paths in sources to unix paths', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld8.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sources).toEqual([
+          '../helloworld.js',
+          '../test1.js',
+        ]);
+        done(err);
+      });
+    });
+
+    it('sets file.relative as file property in sourcemap', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.stem = 'brandnew';
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.file).toEqual('brandnew.js');
+        done(err);
+      });
+    });
+
+    it('normalizes Windows paths in file.relative before using in sourcemap', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.stem = 'assets\\\\brandnew';
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.file).toEqual('assets/brandnew.js');
+        done(err);
+      });
+    });
+
+    it('uses relative sourceRoot to resolve sources', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld5.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sourceRoot).toEqual('test');
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          content,
+          "console.log('test1');\n",
+        ]);
+        done(err);
+      });
+    });
+
+    it('uses absolute sourceRoot to resolve sources', function (done) {
+      var map = convert.fromObject(makeSourcemap());
+      delete map.sourcemap.sourcesContent;
+      var inline = map.toComment();
+      var content = sourceContent + '\n';
+      var file = makeFile(stream.Readable.from(content + inline));
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sourceRoot).toEqual(
+          path.join(__dirname, 'assets')
+        );
+        expect(outFile.sourceMap.sourcesContent).toEqual([
+          "console.log('test1');\n",
+          "console.log('test2');\n",
+        ]);
+        done(err);
+      });
+    });
+
+    it('does not load sourcesContent when sourceRoot is a url', function (done) {
+      var content = sourceContent + '\n';
+      var file = makeFile(
+        stream.Readable.from(
+          content + '//# sourceMappingURL=helloworld6.js.map'
+        )
+      );
+      sourcemaps.add(file, function (err, outFile) {
+        expect(outFile.sourceMap).toBeTruthy();
+        expect(outFile.sourceMap.sourceRoot).toEqual('http://example.com/');
+        expect(outFile.sourceMap.sourcesContent).toEqual([null, null]);
+        done(err);
+      });
+    });
+  });
+}
+
+suite('stream');
+suite('streamx');
+suite('readable-stream');

--- a/test/write.js
+++ b/test/write.js
@@ -5,8 +5,6 @@ var os = require('os');
 var path = require('path');
 var File = require('vinyl');
 var expect = require('expect');
-var streamx = require('streamx');
-var stream = require('stream');
 
 var sourcemaps = require('..');
 
@@ -80,28 +78,6 @@ describe('write', function () {
       expect(
         err instanceof Error &&
           err.message === 'vinyl-sourcemap-write: Not a vinyl file'
-      ).toBeTruthy();
-      done();
-    });
-  });
-
-  it('errors if file argument is a Vinyl object with contents from streamx.Readable', function (done) {
-    var file = makeFile(streamx.Readable.from([]));
-    sourcemaps.write(file, function (err) {
-      expect(
-        err instanceof Error &&
-          err.message === 'vinyl-sourcemap-write: Streaming not supported'
-      ).toBeTruthy();
-      done();
-    });
-  });
-
-  it('errors if file argument is a Vinyl object with contents from stream.Readable', function (done) {
-    var file = makeFile(stream.Readable.from([]));
-    sourcemaps.write(file, function (err) {
-      expect(
-        err instanceof Error &&
-          err.message === 'vinyl-sourcemap-write: Streaming not supported'
       ).toBeTruthy();
       done();
     });
@@ -229,6 +205,20 @@ describe('write (buffer contents)', function () {
     });
   });
 
+  it('uses \\r depending on the existing style', function (done) {
+    var customContents = sourceContent.replace(/\n/g, '\r');
+    var file = makeFile(Buffer.from(customContents));
+    sourcemaps.write(file, function (err, updatedFile) {
+      expect(updatedFile.contents.toString()).toEqual(
+        customContents +
+          '//# sourceMappingURL=' +
+          base64JSON(updatedFile.sourceMap) +
+          '\r'
+      );
+      done(err);
+    });
+  });
+
   it('uses os.EOL if no EOL in contents', function (done) {
     var customContents = sourceContent.replace(/\n/g, '');
     var file = makeFile(Buffer.from(customContents));
@@ -305,3 +295,345 @@ describe('write (buffer contents)', function () {
     });
   });
 });
+
+function suite(moduleName) {
+  var stream = require(moduleName);
+
+  describe('write (' + moduleName + ' contents)', function () {
+    function concat(fn, timeout) {
+      var items = [];
+      return new stream.Writable({
+        objectMode: true,
+        write: function (chunk, enc, cb) {
+          if (typeof enc === 'function') {
+            cb = enc;
+          }
+          setTimeout(function () {
+            items.push(chunk);
+            cb();
+          }, timeout || 1);
+        },
+        final: function (cb) {
+          if (typeof fn === 'function') {
+            fn(items.join(''));
+          }
+
+          cb();
+        },
+      });
+    }
+
+    it('does not error if file argument is a Vinyl object with Stream contents', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, function (err) {
+        expect(err).toBeFalsy();
+        done();
+      });
+    });
+
+    it('accepts null destPath argument', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, null, function (err) {
+        expect(err).toBeFalsy();
+        done(err);
+      });
+    });
+
+    it('accepts undefined destPath argument', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, undefined, function (err) {
+        expect(err).toBeFalsy();
+        done(err);
+      });
+    });
+
+    it('accepts string destPath argument', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, 'something', function (err) {
+        expect(err).toBeFalsy();
+        done(err);
+      });
+    });
+
+    it('juggles callback if no destPath argument', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, function (err) {
+        expect(err).toBeFalsy();
+        done(err);
+      });
+    });
+
+    it('calls back with the untouched file if sourceMap property does not exist', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      delete file.sourceMap;
+      sourcemaps.write(file, function (err, outFile) {
+        expect(err).toBeFalsy();
+        expect(file).toBeTruthy();
+        expect(outFile).toEqual(file);
+        done(err);
+      });
+    });
+
+    it('appends an inline sourcemap when no destPath', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, function (err, updatedFile, sourceMapFile) {
+        expect(err).toBeFalsy();
+        expect(updatedFile).toBeTruthy();
+        expect(sourceMapFile).toBeFalsy();
+        expect(File.isVinyl(updatedFile)).toEqual(true);
+        expect(updatedFile).toEqual(file);
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            sourceContent +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('appends /*# */ comment if .css extension', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.path = file.path.replace('.js', '.css');
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            sourceContent +
+              '/*# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              ' */\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('appends //# comment if any non-.css extension', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      file.path = file.path.replace('.js', '.txt');
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            sourceContent +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('uses \\r\\n depending on the existing style', function (done) {
+      var customContents = sourceContent.replace(/\n/g, '\r\n');
+      var file = makeFile(stream.Readable.from(customContents));
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            customContents +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\r\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('only uses the final newline for the existing style', function (done) {
+      var customContents = sourceContent.replace(/\n/, '\r\n');
+      var file = makeFile(stream.Readable.from(customContents));
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            customContents +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('uses \\r depending on the existing style', function (done) {
+      var customContents = sourceContent.replace(/\n/g, '\r');
+      var file = makeFile(stream.Readable.from(customContents));
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            customContents +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\r'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('uses os.EOL if no EOL in contents', function (done) {
+      var customContents = sourceContent.replace(/\n/g, '');
+      var file = makeFile(stream.Readable.from(customContents));
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            customContents +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              os.EOL
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('also works with stream chunks that are buffers', function (done) {
+      var customContents = sourceContent.replace(/\n/g, '\r\n');
+      // We use the array here so readable-stream doesn't iterate the entire buffer by byte
+      var file = makeFile(stream.Readable.from([Buffer.from(customContents)]));
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            customContents +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\r\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('detects CRLF across chunks', function (done) {
+      // Assumes to be 3 chunks but the last is an empty string
+      var contentChunks = sourceContent.split('\n');
+      var file = makeFile(
+        stream.Readable.from([
+          contentChunks[0],
+          '\r\n',
+          contentChunks[1] + '\r',
+          '\n',
+        ])
+      );
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            contentChunks.join('\r\n') +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\r\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('detects CR across chunks without any LF', function (done) {
+      // Assumes to be 3 chunks but the last is an empty string
+      var contentChunks = sourceContent.split('\n');
+      var file = makeFile(
+        stream.Readable.from([contentChunks[0], '\r', contentChunks[1] + '\r'])
+      );
+      sourcemaps.write(file, function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            contentChunks.join('\r') +
+              '//# sourceMappingURL=' +
+              base64JSON(updatedFile.sourceMap) +
+              '\r'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+
+    it('writes an external sourcemap when given a destPath', function (done) {
+      var file = makeFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(
+        file,
+        '../maps',
+        function (err, updatedFile, sourceMapFile) {
+          expect(err).toBeFalsy();
+
+          expect(File.isVinyl(updatedFile)).toEqual(true);
+          expect(updatedFile).toEqual(file);
+
+          expect(File.isVinyl(sourceMapFile)).toEqual(true);
+          expect(sourceMapFile.path).toEqual(
+            path.join(__dirname, 'maps/helloworld.js.map')
+          );
+          expect(JSON.parse(sourceMapFile.contents)).toEqual(
+            updatedFile.sourceMap
+          );
+          expect(sourceMapFile.stat.isFile()).toEqual(true);
+          expect(sourceMapFile.stat.isDirectory()).toEqual(false);
+          expect(sourceMapFile.stat.isBlockDevice()).toEqual(false);
+          expect(sourceMapFile.stat.isCharacterDevice()).toEqual(false);
+          expect(sourceMapFile.stat.isSymbolicLink()).toEqual(false);
+          expect(sourceMapFile.stat.isFIFO()).toEqual(false);
+          expect(sourceMapFile.stat.isSocket()).toEqual(false);
+
+          function assert(contents) {
+            expect(contents).toEqual(
+              sourceContent + '//# sourceMappingURL=../maps/helloworld.js.map\n'
+            );
+          }
+
+          stream.pipeline([updatedFile.contents, concat(assert)], done);
+        }
+      );
+    });
+
+    it('create shortest path to map in file comment', function (done) {
+      var file = makeNestedFile(stream.Readable.from(sourceContent));
+      sourcemaps.write(file, 'dir1/maps', function (err, updatedFile) {
+        expect(err).toBeFalsy();
+
+        function assert(contents) {
+          expect(contents).toEqual(
+            sourceContent +
+              '//# sourceMappingURL=../maps/dir1/dir2/helloworld.js.map\n'
+          );
+        }
+
+        stream.pipeline([updatedFile.contents, concat(assert)], done);
+      });
+    });
+  });
+}
+
+suite('stream');
+suite('streamx');
+suite('readable-stream');


### PR DESCRIPTION
Started working on streaming support for this.  The `write` method was easy because it assumed that `.sourceMap` exists on the file so I just needed to add the comment to the stream.

I'm hoping to give the `add` stuff a go in the next few days as long as nothing major comes up.

Closes #32 
Closes #36 

cc @erikkemperman @nmccready @robinvenneman 