### PR TITLE
chore: Normalize repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ MIT
 [npm-image]: https://img.shields.io/npm/v/vinyl-sourcemap.svg?style=flat-square
 
 [ci-url]: https://github.com/gulpjs/vinyl-sourcemap/actions?query=workflow:dev
-[ci-image]: https://img.shields.io/github/workflow/status/gulpjs/vinyl-sourcemap/dev?style=flat-square
+[ci-image]: https://img.shields.io/github/actions/workflow/status/gulpjs/vinyl-sourcemap/dev.yml?branch=master&style=flat-square
 
 [coveralls-url]: https://coveralls.io/r/gulpjs/vinyl-sourcemap
 [coveralls-image]: https://img.shields.io/coveralls/gulpjs/vinyl-sourcemap/master.svg?style=flat-square


### PR DESCRIPTION
The URL of GitHub workflow badge was changed by `badges/shields`'s issue `#8671`.
This PR modifies the URL in `README.md`.